### PR TITLE
Fix "edit on github" links

### DIFF
--- a/siteConfig.json
+++ b/siteConfig.json
@@ -9,7 +9,7 @@
   "SITE_URL": "https://eulalia.xyz",
   "PINNED_POSTS": [],
   "REPO_URL": "",
-  "EDIT_POST_URL": "",
+  "EDIT_POST_URL": "https://github.com/clairdl/eulalia.xyz/tree/master/posts",
   "BUTTON_DOWN_USER": "clairdl",
   "GOAT_COUNTER": "clairdl",
   "LAYOUT_WIDTH": 950


### PR DESCRIPTION
(Assuming this feature isn't going to be removed)

Without this config variable, the `edit on github` link goes to `https://www.eulalia.xyz/hello-world.md` when it should go to `https://github.com/clairdl/eulalia.xyz/blob/master/posts/hello-world.md`